### PR TITLE
fix(front): adapt to zod v4

### DIFF
--- a/packages/front/app/lib/http/request/parser.server.spec.ts
+++ b/packages/front/app/lib/http/request/parser.server.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { handleZodError, parseJson } from './parser.server'
-import { ZodError } from 'zod'
+import { z } from 'zod'
 
 describe('parseJson', () => {
   it('should not throw valid json request', async () => {
@@ -25,17 +25,11 @@ describe('parseJson', () => {
 
 describe('handleZodError', () => {
   it('should throw as bad-request with the given error details', async () => {
-    const zodError = new ZodError([
-      {
-        code: 'invalid_type',
-        expected: 'string',
-        received: 'undefined',
-        path: ['field'],
-        message: 'field is required',
-      },
-    ])
+    const schema = z.object({ field: z.string() })
+    const result = schema.safeParse({})
+    if (result.success) throw new Error('Expected schema validation to fail')
 
-    await expect(async () => handleZodError(zodError)).rejects.toHaveProperty(
+    await expect(async () => handleZodError(result.error)).rejects.toHaveProperty(
       'status',
       400,
     )

--- a/packages/front/app/lib/http/request/parser.server.ts
+++ b/packages/front/app/lib/http/request/parser.server.ts
@@ -1,4 +1,4 @@
-import type { z, ZodError, ZodObject, ZodRawShape } from 'zod'
+import type { z, ZodError } from 'zod'
 import { badRequest } from '~/lib/http/response/json/error.server'
 import { makeCatchesSerializable } from '~/lib/error'
 
@@ -20,17 +20,17 @@ export async function parseJson<R extends Request>(
 export function handleZodError(error: ZodError): never {
   console.error({
     message: 'request data is invalid',
-    error: error.errors,
+    error: error.issues,
   })
 
   throw badRequest({
     code: 'invalid-body-scheme',
     message: 'Request body does not match the expected scheme',
-    detail: error.errors,
+    detail: error.issues,
   })
 }
 
-export function parseQuery<S extends ZodObject<ZRS>, ZRS extends ZodRawShape>(
+export function parseQuery<S extends z.ZodTypeAny>(
   request: Request,
   scheme: S,
 ): z.infer<S> {


### PR DESCRIPTION
\nfix(front): adapt to zod v4\n\n- Replace ZodError.errors with .issues\n- Remove ZodRawShape and relax parseQuery generic to z.ZodTypeAny\n- Update tests to generate ZodError via schema.safeParse failure\n\nThis resolves CI failures caused by breaking changes in zod v4.\n