### PR TITLE
fix command message

### DIFF
--- a/packages/discord-bot/src/bot/commands/archive-challenge.ts
+++ b/packages/discord-bot/src/bot/commands/archive-challenge.ts
@@ -7,7 +7,20 @@ import { log } from '../../lib/log.js'
 import { makeCatchesSerializable } from '../../lib/error.js'
 import { type Command } from './index.js'
 
-const successMessage = 'アーカイブに登録しました'
+function createSuccessMessage(title: string, url: string, description?: string): string {
+  const lines = [
+    'アーカイブに登録しました',
+    '',
+    `**タイトル:** ${title}`,
+    `**URL:** ${url}`,
+  ]
+
+  if (description) {
+    lines.push(`**説明:** ${description}`)
+  }
+
+  return lines.join('\n')
+}
 const invalidResponseMessage = 'アーカイブ追加中にエラーが発生しました'
 const commandFailureMessage = 'アーカイブ追加に失敗しました'
 const disallowedChannelMessage =
@@ -126,6 +139,7 @@ export const archiveChallengeCommand: Command = {
       })
 
       if (response.ok) {
+        const successMessage = createSuccessMessage(title, url, descriptionOption)
         await interaction.editReply({ content: successMessage })
         return
       }

--- a/packages/discord-bot/src/bot/commands/archive-challenge.ts
+++ b/packages/discord-bot/src/bot/commands/archive-challenge.ts
@@ -7,7 +7,11 @@ import { log } from '../../lib/log.js'
 import { makeCatchesSerializable } from '../../lib/error.js'
 import { type Command } from './index.js'
 
-function createSuccessMessage(title: string, url: string, description?: string): string {
+function createSuccessMessage(
+  title: string,
+  url: string,
+  description?: string,
+): string {
   const lines = [
     'アーカイブに登録しました',
     '',
@@ -139,7 +143,11 @@ export const archiveChallengeCommand: Command = {
       })
 
       if (response.ok) {
-        const successMessage = createSuccessMessage(title, url, descriptionOption)
+        const successMessage = createSuccessMessage(
+          title,
+          url,
+          descriptionOption,
+        )
         await interaction.editReply({ content: successMessage })
         return
       }


### PR DESCRIPTION
このプルリクエストは、Discordボットでアーカイブを登録する際のユーザーフィードバックを改善し、より詳細な成功メッセージを提供します。主な変更点は、アーカイブのタイトル、URL、およびオプションの説明を含むフォーマットされた成功メッセージを生成する新関数の導入です。

ユーザーフィードバックの強化:

* タイトル、URL、オプションの説明でアーカイブ登録の成功メッセージをフォーマットする`createSuccessMessage`関数を追加し、応答の情報を充実させました。
* ユーザーへの成功返信送信時に、新しい`createSuccessMessage`関数を使用するようコマンドロジックを更新しました。